### PR TITLE
Rumi

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -1,6 +1,6 @@
 #include "memory.h"
 
-//#define __DPDK
+#define __DPDK
 
 #ifdef __DPDK
 #include <rte_malloc.h>
@@ -35,7 +35,7 @@ void *mem_alloc_align(size_t align, size_t size) {
 
     memset(addr, 0, size);
 #else
-    addr = rte_malloc_socket(0, size, align, 1);
+    addr = rte_zmalloc_socket(0, size, align, 1);
 #endif
     return addr;
 }

--- a/tests/checksum-checksum/benchmark.sh
+++ b/tests/checksum-checksum/benchmark.sh
@@ -10,14 +10,14 @@ OUTDIR=${CWD}/output
 mkdir -p ${OUTDIR}
 
 cd ${CWD}/../../
-rm main
 
 for pkt in ${PACKET_SIZE[@]}; do
     printf "CHECKSUM\tCHECKSUM 2\tPACKET_SIZE\tCYCLES\n"
     for chksum in ${SWEEP_BUFFERS[@]}; do
         for chksumm in ${SWEEP_BUFFERS[@]}; do
             printf "$chksum\t$chksumm\t$pkt\t"
-            make jit-test BENCHMARK=${BENCHMARK} EXTRA="-DREPEAT=200 -DPACKET_SIZE=${pkt} -DCHECKSUM_BUFFER_SIZE_2=${chksumm} -DCHECKSUM_BUFFER_SIZE_1=${chksum}" && make && sudo ./bin/main | grep cycles | rev | cut -d' ' -f1 | sed -e 's/[()]//g' | rev
+            EXTRA="-DREPEAT=200 -DPACKET_SIZE=${pkt} -DCHECKSUM_BUFFER_SIZE_2=${chksumm} -DCHECKSUM_BUFFER_SIZE_1=${chksum}"
+            make clean && make jit-test PROFILE=optimized BENCHMARK=${BENCHMARK} EXTRA="$EXTRA" && make main EXTRA="$EXTRA" && sudo ./bin/main | grep cycles | rev | cut -d' ' -f1 | sed -e 's/[()]//g' | rev
         done
     done | tee "${OUTDIR}/$pkt.tsv"
 done


### PR DESCRIPTION
This fixes the memory allocation, making the benchmark much faster. It still feels slow for the packet count.

This also changes a test so that it actually takes the extra parameters into account. But it's not viable to make clean in order to do so. Is there a better way? Also, do we need the extra both in the jit-test.so and the main?